### PR TITLE
Migrate to proc-macro

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,18 +1,39 @@
 name: Build
-on: [push]
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
 jobs:
-  main:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # 7.6 is not yet supported properly. Once fixed, this can be set to true
+      matrix:
+        include:
+          - setup: varnish74
+          - setup: varnish75
+          - setup: varnish76
+    env:
+      RUST_BACKTRACE: 1
+      RUSTDOCFLAGS: -D warnings
+      RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: |
-          sudo apt-get install -y curl
-          curl -s https://packagecloud.io/install/repositories/varnishcache/varnish75/script.deb.sh | sudo bash
-          sudo apt-get install varnish-dev
-      - run: |
-          cargo doc
-          cargo build
-          cargo test
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - name: Ensure this crate has not yet been published (on release)
+        if: github.event_name == 'release'
+        run: just check-if-published
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: install varnish-dev
+        run: |
+          curl -s https://packagecloud.io/install/repositories/varnishcache/${{ matrix.setup }}/script.deb.sh | sudo bash
+          sudo apt-get install -y varnish-dev
+      - run: just -v ci-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,16 +24,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -42,7 +40,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -50,6 +47,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cexpr"
@@ -78,19 +84,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "libc",
- "windows-sys",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -120,34 +196,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.9"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys",
-]
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "itoa"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
@@ -164,12 +231,6 @@ dependencies = [
  "cfg-if",
  "windows-targets",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -293,17 +354,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustix"
-version = "0.38.37"
+name = "ryu"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
@@ -326,10 +380,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -343,6 +426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,22 +440,36 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 [[package]]
 name = "varnish"
 version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98deff452d19846a43892821647e81e5520291d8d006464c31d8e280e1fda139"
+source = "git+https://github.com/gquintard/varnish-rs.git?branch=feature-macro#a99d66cdb32a4da309b283ba3bccc46bfd9ddf04"
 dependencies = [
- "pkg-config",
- "serde",
+ "glob",
+ "varnish-macros",
+ "varnish-sys",
+]
+
+[[package]]
+name = "varnish-macros"
+version = "0.0.19"
+source = "git+https://github.com/gquintard/varnish-rs.git?branch=feature-macro#a99d66cdb32a4da309b283ba3bccc46bfd9ddf04"
+dependencies = [
+ "darling",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "sha2",
+ "syn",
  "varnish-sys",
 ]
 
 [[package]]
 name = "varnish-sys"
 version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21a779a3c486b0cf616b5980c7a561f11575bc267db5144263593cf8906c646"
+source = "git+https://github.com/gquintard/varnish-rs.git?branch=feature-macro#a99d66cdb32a4da309b283ba3bccc46bfd9ddf04"
 dependencies = [
  "bindgen",
  "pkg-config",
+ "serde",
 ]
 
 [[package]]
@@ -382,6 +485,7 @@ dependencies = [
  "lru",
  "regex",
  "varnish",
+ "varnish-macros",
  "varnish-sys",
 ]
 
@@ -390,27 +494,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,12 @@ name = "vmod_rers"
 version = "0.0.9"
 edition = "2021"
 
-[build-dependencies]
-varnish = "0.0.19"
-
 [dependencies]
-varnish = "0.0.19"
-varnish-sys = "0.0.19"
-regex = "1.5"
 lru = "0.7.1"
+regex = "1.5"
+varnish = { git = "https://github.com/gquintard/varnish-rs.git", branch = "feature-macro"}
+varnish-macros = { git = "https://github.com/gquintard/varnish-rs.git", branch = "feature-macro" }
+varnish-sys = { git = "https://github.com/gquintard/varnish-rs.git", branch = "feature-macro"}
 
 [lib]
 crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ As usual, the full VCL API is described in [vmod.vcc](vmod.vcc), and if you need
 
 ## VCL Example
 
-``` bash
+```bash
 import rers;
 
 sub vcl_init {
@@ -53,7 +53,7 @@ Depending on which `varnish` version tou are targeting, select the right `vmod_r
 
 With `cargo` only:
 
-``` bash
+```bash
 cargo build --release
 cargo test --release
 ```
@@ -62,7 +62,7 @@ The vmod file will be found at `target/release/libvmod_rs_template.so`.
 
 Alternatively, if you have `jq` and `rst2man`, you can use `build.sh`
 
-``` bash
+```bash
 ./build.sh [OUTDIR]
 ```
 
@@ -75,7 +75,7 @@ To avoid making a mess of your system, you probably should install your vmod as 
 ### All platforms
 
 First it's necessary to set the `VMOD_VERSION` (the version of this vmod) and `VARNISH_VERSION` (the Varnish version to build against) environment variables. It can be done manually, or using `cargo` and `jq`:
-``` bash
+```bash
 VMOD_VERSION=$(cargo metadata --no-deps --format-version 1 | jq '.packages[0].version' -r)
 VARNISH_MINOR=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "varnish-sys") | .metadata.libvarnishapi.version ')
 VARNISH_PATCH=0
@@ -88,7 +88,7 @@ VARNISH_VERSION=7.0.0
 
 Then create the dist tarball, for example using `git archive`:
 
-``` bash
+```bash
 git archive --output=vmod_rs_template-$VMOD_VERSION.tar.gz --format=tar.gz HEAD
 ```
 
@@ -96,7 +96,7 @@ Then, follow distribution-specific instructions.
 
 ### Arch
 
-``` bash
+```bash
 # create a work directory
 mkdir build
 # copy the tarball and PKGBUILD file, substituing the variables we care about
@@ -114,7 +114,7 @@ Your package will be the file with the `.pkg.tar.zst` extension in `build/`
 
 Alpine needs a bit of setup on the first time, but the [documentation](https://wiki.alpinelinux.org/wiki/Creating_an_Alpine_package) is excellent.
 
-``` bash
+```bash
 # install some packages, create a user, give it power and a key
 apk add -q --no-progress --update tar alpine-sdk sudo
 adduser -D builder
@@ -125,7 +125,7 @@ su builder -c "abuild-keygen -nai"
 
 Then, to actually build your package:
 
-``` bash
+```bash
 # create a work directory
 mkdir build
 # copy the tarball and PKGBUIL file, substituing the variables we care about

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,0 @@
-// before we actually compile our code, parse `vmod.vcc` to generate some boilerplate
-fn main() {
-    varnish::generate_boilerplate().unwrap();
-}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,69 @@
+#!/usr/bin/env just --justfile
+
+@_default:
+    just --list --unsorted
+
+# Clean all build artifacts
+clean:
+    cargo clean
+    rm -f Cargo.lock
+
+# Update dependencies, including breaking changes
+update:
+    cargo +nightly -Z unstable-options update --breaking
+    cargo update
+
+# Run cargo clippy
+clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Test code formatting
+test-fmt:
+    cargo fmt --all -- --check
+
+# Run cargo fmt
+fmt:
+    cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
+
+# Build and open code documentation
+docs:
+    cargo doc --no-deps --open
+
+# Quick compile
+check:
+    cargo check --workspace --all-targets
+
+# Default build
+build:
+    cargo build --workspace --all-targets
+
+# Run all tests
+test: build
+    cargo test --workspace --all-targets
+
+# Test documentation
+test-doc:
+    cargo doc --no-deps
+
+rust-info:
+    rustc --version
+    cargo --version
+
+# Run all tests as expected by CI
+ci-test: rust-info test-fmt clippy test test-doc
+
+# Verify that the current version of the crate is not the same as the one published on crates.io
+check-if-published:
+    #!/usr/bin/env bash
+    LOCAL_VERSION="$(grep '^version =' Cargo.toml | sed -E 's/version = "([^"]*)".*/\1/')"
+    echo "Detected crate version:  $LOCAL_VERSION"
+    CRATE_NAME="$(grep '^name =' Cargo.toml | head -1 | sed -E 's/name = "(.*)"/\1/')"
+    echo "Detected crate name:     $CRATE_NAME"
+    PUBLISHED_VERSION="$(cargo search ${CRATE_NAME} | grep "^${CRATE_NAME} =" | sed -E 's/.* = "(.*)".*/\1/')"
+    echo "Published crate version: $PUBLISHED_VERSION"
+    if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+        echo "ERROR: The current crate version has already been published."
+        exit 1
+    else
+        echo "The current crate version has not yet been published."
+    fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,13 +251,13 @@ impl VDP for Vxp {
         NAME
     }
 
-    fn new(vrt_ctx: &mut Ctx, vdp_ctx: &mut VDPCtx) -> InitResult<Vxp> {
+    fn new(vrt_ctx: &mut Ctx, _: &mut VDPCtx) -> InitResult<Vxp> {
         // we don't know how/if the body will be modified, so we nuke the content-length
         // it's also not worth fleshing out a rust object just to remove a header, we just use the C functions
         unsafe {
-            let req = vdp_ctx.raw.req.as_ref().unwrap();
+            let req = vrt_ctx.raw.req.as_ref().unwrap();
             assert_eq!(req.magic, ffi::REQ_MAGIC);
-            ffi::http_Unset((*vdp_ctx.raw.req).resp, ffi::H_Content_Length.as_ptr());
+            ffi::http_Unset((*vrt_ctx.raw.req).resp, ffi::H_Content_Length.as_ptr());
         }
 
         Vxp::new(vrt_ctx)


### PR DESCRIPTION
Things to consider:
* repl is slightly slower because it uses to_string()
  * I plan to address this in a more general way in the future - as a set of new primitives that can automatically push things into WS as part of code generation.
* I suspect using a different sync primitive (e.g. readwrite lock) would be far bigger influence